### PR TITLE
Bug/payment type fix

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -15,7 +15,7 @@ router.register(r'customers', Customers, 'customer')
 router.register(r'users', Users, 'user')
 router.register(r'orders', Orders, 'order')
 router.register(r'cart', Cart, 'cart')
-router.register(r'paymenttypes', Payments, 'payment')
+router.register(r'payment-types', Payments, 'payment')
 router.register(r'profile', Profile, 'profile')
 
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,11 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        #customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added customer variable to the 'list' function of the 'payment type' view to save an instance of a Customer where the customer user_id = the authenticated user.id. Commented out query param variable definition to potentially use later. Also changed the url route to "payment-types" to reflect client request.


## Requests / Responses

**Request**

GET `/payment-types` requests all payment types associated with the authenticated user

```json

```

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "url": "http://localhost:8000/payment-types/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
    }
]
```

## Testing

- [ ] using postman, make a get request to http://localhost:8000/payment-types with valid Auth token header. Try a different token to confirm unique data. 



## Related Issues

- Fixes #36
- Fixes #35