### PR TITLE
updated views/profile.py to remove line_items

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,7 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                #cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
## Issue addressed

When navigating to  /profile/cart, the following two keys are on the response object, resulting in duplicated cart items:

lineitems
line_items

## Changes

- We've commented out line 187 from views/profile.py: "cart["order"]["line_items"] = line_items.data"

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/profile/cart` displays the items in a user's cart

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "Golf",
                "price": 653.59,
                "number_sold": 0,
                "description": "1994 Volkswagen",
                "quantity": 4,
                "created_date": "2019-07-10",
                "location": "Berlin",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        },
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "New York",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "London",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 3
}
```

## Testing

- test in Postman or related API testing platform

## Related Issues

- Fixes #42