### PR TITLE
added delete method to lineitem destroy function

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,7 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-
+            order_product.delete()
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
## Changes

- Added .delete() method to selected order_product in the destroy function of the lineitem view
- Removed pesky Pipfile and reset virtual env

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

DELETE `/lineitems/x` deletes orderitem id x


**Response**

HTTP/1.1 204 NO CONTENT


## Testing

Description of how to test code...

- [ ] when logged in as an authenticated user, navigate to /cart and click trash icon next to an item 


## Related Issues

- Fixes #37 