### PR TITLE
Added functionality for payment to be added to order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -107,7 +107,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Order class update method was attempting to save order payment type as a string. Corrected to add payment type as an instance of Payment.

## Changes

- Changed order.payment_type to be equal to Payment.objects.get(pk=request.data["payment_type"])

## Requests / Responses

**Request**

PUT `/orders/2` Adds a payment method to the order id in the url, thus completing the order.

```json
{
    "payment_type": "3"
}
```

**Response**

HTTP/1.1 204 No Content

```json
{}
```
## Testing

- [ ] re-seed database from terminal with ./seed_data.sh
- [ ] using Token 9ba45f09651c5b0c404f37a2d2572c026c14669c, run a PUT request to http://localhost:8000/orders/2 with a body of {"payment_type": "3"} 
- [ ] output should be an empty object with status code 204


## Related Issues

- Fixes #12
