### PR TITLE
Bug #54 fixed; can now add item to cart

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from bangazonapi.models import Order, Customer, Product, OrderProduct
 from .product import ProductSerializer
 from .order import OrderSerializer
+from .profile import LineItemSerializer
 
 
 class Cart(ViewSet):
@@ -36,8 +37,9 @@ class Cart(ViewSet):
         line_item.product = Product.objects.get(pk=request.data["product_id"])
         line_item.order = open_order
         line_item.save()
+        serializer = LineItemSerializer(line_item, many=False)
 
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
     def destroy(self, request, pk=None):


### PR DESCRIPTION
## Changes

Imported/employed the LineItemSerializer; changed the response body to show a successful creation as client was expecting a response

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/cart`: adds a new product to the existing user's open cart

```json
{
  "product_id": 88
}
```

**Response**

HTTP/1.1 201 Created

```json
{
"id": 12,
    "product": {
        "id": 88,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Moscow",
        "image_path": "/media/products/vehicle.png",
        "average_rating": 0
    }
}
```

## Testing

- Visit "Add item to cart" in the "Collections" folder of Postman
- Run a "Post" action to "http://localhost:8000/cart" with the below as the body: 
{
    "product_id": 88
}
- JSON response should return an order product ID & object a la the "Response" section above


## Related Issues

- Fixes #54
