### PR TITLE
added incomplete orders report

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -78,7 +78,7 @@ ROOT_URLCONF = 'bangazon.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     path('login', login_user),
     path('api-token-auth', obtain_auth_token),
     path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path('reports/orders', orders_report, name='orders_report'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/templates/incomplete_orders.html
+++ b/bangazonapi/templates/incomplete_orders.html
@@ -1,0 +1,29 @@
+<!-- templates/report_template.html -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Report for Incomplete Orders</title>
+</head>
+<body>
+    <h1>Report for Incomplete Orders</h1>
+    <!-- Display the report data -->
+    <table border="1">
+        <thead>
+            <tr>
+                <th>Order ID</th>
+                <th>Customer Name</th>
+                <th>Order Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in orders %}
+                <tr>
+                    <td>{{ item.id }}</td>
+                    <td>{{ item.customer.user.first_name }} {{ item.customer.user.last_name }}</td>
+                    <td>${{ item.total }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,3 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
+from .reports import orders_report

--- a/bangazonapi/views/reports.py
+++ b/bangazonapi/views/reports.py
@@ -1,0 +1,10 @@
+from django.shortcuts import render
+from bangazonapi.models import Order
+
+def orders_report(request):
+    status = request.GET.get('status', None)
+
+    if status is not None and status == 'incomplete':
+        orders = Order.objects.filter(payment_type__isnull=True).select_related('customer', 'customer__user')
+        context = {'orders': orders}
+        return render(request, 'incomplete_orders.html', context)


### PR DESCRIPTION
## Changes

- Configured template settings in settings.py
- Added path for order reports in url patters of urls.py
- Created a templates folder in bangazon directory to house django template html files
- Created a reports module in the views directory
- Defined an orders_report function within the reports module to handle logic of filtering open orders and render the django incomplete_orders template with provided context
- Imported this function to the dunder init file for views, to be accessed by urls module

## Testing

In a browser, navigate to http://localhost:8000/reports/orders?status=incomplete 
Order ID, customer name, and order total for all incomplete orders should appear in a table. 

## Related Issues

- Fixes #32