### PR TITLE
Test/complete order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -119,8 +119,9 @@ class OrderTests(APITestCase):
         # Verify the order has the payment type assigned
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
+        payment_id = int(json_response["payment_type"].rstrip('/').split('/')[-1])
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json_response["payment_type"], self.payment_type)
+        self.assertEqual(payment_id, self.payment_type)
 
-    # TODO: New line item is not added to closed order
+    # TODO: New line item is not added to closed order  

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,6 +1,9 @@
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import Order, Customer
+from django.contrib.auth.models import User
+
 
 
 class OrderTests(APITestCase):
@@ -16,6 +19,10 @@ class OrderTests(APITestCase):
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # Retrieve or create a customer instance for the user
+        self.user = User.objects.get(username='steve')
+        self.customer = Customer.objects.get(user=self.user)
+
         # Create a product category
         url = "/productcategories"
         data = {"name": "Sporting Goods"}
@@ -28,6 +35,22 @@ class OrderTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Create a payment type
+        url = "/payment-types"
+        data = {"merchant_name": "Visa", "account_number": 12345671234590, "customer_id": 1, "expiration_date": "2020-03-11", "create_date": "2015-03-11"}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.payment_type = response.data['id']
+
+        # Create an order using ORM
+        self.order = Order.objects.create(
+            customer=self.customer,  # Use Customer instance
+            payment_type=None,
+            created_date='2024-06-10'
+        )
+        self.order_id = self.order.id
 
 
     def test_add_product_to_order(self):
@@ -79,6 +102,25 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["size"], 0)
         self.assertEqual(len(json_response["lineitems"]), 0)
 
-    # TODO: Complete order by adding payment type
+
+    # Complete order by adding payment type
+
+    def test_add_payment_type_to_order(self):
+        """
+        Ensure we can complete an order by adding a payment type
+        """
+        # Add a payment type to an existing order
+        url = f"/orders/{self.order_id}"
+        data = { "payment_type": self.payment_type }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Verify the order has the payment type assigned
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["payment_type"], self.payment_type)
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
Added test method to OrderTests class for adding payment type to an order, as well as payment type and order in setup. 

## Changes

- Imported User, Order, and Customer models
- Created Customer and User instances in test db
- Created a payment type
- Created an order with ORM 
- Created a test method to add payment to an order, which checks the status of the order PUT, then gets the order and checks that the status is ok and that the payment type equals the type added at the beginning of the test.

## Testing

Description of how to test code...

- [ ] In terminal, run:  python3 manage.py test tests.OrderTests.test_add_payment_type_to_order
- [ ] This should return 'OK' in terminal

## Related Issues

- Fixes #27